### PR TITLE
fix(ci): Fix cosign signing loop exiting after first file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -456,7 +456,7 @@ jobs:
             fi
 
             echo "✓ Signed successfully"
-            ((SIGNED_COUNT++))
+            SIGNED_COUNT=$((SIGNED_COUNT + 1))
           done <<< "$ARCHIVES"
 
           echo ""


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the release workflow's cosign signing step that was causing only 1 out of 9 platform archives to be signed.

- **🐛 Bug Fix**: Cosign loop now signs all archives instead of exiting after the first
- **🔍 Root Cause**: Bash arithmetic expression `((SIGNED_COUNT++))` incompatible with `set -e`

## Key Changes

### 🐛 Critical Bug Fix

**Fixed arithmetic expression causing premature loop exit** (.github/workflows/release.yml:459)

**Root cause:**
```bash
set -e  # Exit on any error (line 422)
...
((SIGNED_COUNT++))  # Returns exit code 1 when incrementing from 0!
```

When `SIGNED_COUNT=0`, the expression `((SIGNED_COUNT++))` evaluates the **pre-increment value** (0) and returns it as the exit status. In bash, an arithmetic expression that evaluates to 0 returns exit code 1. With `set -e` active, this caused the script to exit immediately after the first successful signing.

**The fix:**
```bash
SIGNED_COUNT=$((SIGNED_COUNT + 1))  # Always returns exit code 0
```

This form uses variable assignment, which always succeeds (exit code 0), allowing the loop to continue through all archives.

**Evidence from logs:**
```
Found 9 archives to sign
=== Signing: artifacts/ruloc-0.1.2-aarch64-apple-darwin.tar.gz ===
✓ Signed successfully
##[error]Process completed with exit code 1.
```

- Script successfully signed the first archive (aarch64-apple-darwin.tar.gz)
- Loop exited immediately after with exit code 1
- Remaining 8 archives (linux-gnu, linux-musl, windows, etc.) were never signed

**Impact:**
- Before: Only 1/9 platform binaries were signed, releases incomplete
- After: All 9 platform binaries will be signed correctly

## Testing

**Manual verification:**
- ✅ No functional code changes - bash syntax fix only
- ✅ Workflow syntax validated
- ✅ Arithmetic expression tested locally to confirm exit code behavior

**Test case demonstrating the issue:**
```bash
# Reproduces the bug
set -e
COUNT=0
((COUNT++))  # Exits with code 1
echo "This never prints"

# Working version
set -e
COUNT=0
COUNT=$((COUNT + 1))  # Succeeds with code 0
echo "This prints: COUNT=$COUNT"
```

## CI/CD Status

This PR will trigger the CI checks but does not require a full release workflow run to validate (the fix is in release.yml which only runs on version tags).

However, the fix can be validated by:
1. Checking the modified line 459 in release.yml
2. Testing the arithmetic expression behavior locally
3. Next release workflow run will sign all 9 archives successfully

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⭐ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔨 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Testing improvements
- [ ] 🎨 Code style/formatting
- [ ] 🧹 Miscellaneous/chore

## Related Issues

Fixes the cosign signing failure from:
- https://github.com/nutthead/ruloc/actions/runs/18296886900/job/52097156436

This is a follow-up fix to PR #14 which resolved the artifact download structure but uncovered this separate arithmetic bug.

## Breaking Changes

None. This is a bug fix that allows the release workflow to function as originally intended.

## Release Impact

**Version bump**: patch
**Changelog category**: Bug Fixes
**Footer tag**: `$fix`

This fix unblocks releases by ensuring all platform binaries are properly signed with cosign.

## Pre-merge Checklist

- [x] All commits follow conventional commit format (verified via `/c` command)
- [x] Code formatted with `cargo fmt --all` - N/A (workflow change only)
- [x] Clippy passes - N/A (workflow change only)
- [x] All tests pass - N/A (workflow change only)
- [x] Coverage ≥70% maintained - N/A (no code changes)
- [x] Documentation updated where needed - N/A
- [x] Self-review completed
- [ ] CI checks passing (will be verified by GitHub Actions)

## Additional Context

**Why this matters:**

This is a subtle but critical bug that prevented proper artifact signing. Without all artifacts signed:
- Users cannot verify binary authenticity for 8 out of 9 platforms
- SLSA provenance attestation is incomplete
- Supply chain security is compromised

**Bash arithmetic gotchas:**

This is a well-known bash pitfall when using `set -e`:
- `((expr))` returns the value of expr as exit code
- `((0))` returns exit code 1 (false in C-style boolean)
- `((1))` returns exit code 0 (true in C-style boolean)
- Variable assignment `VAR=$((expr))` always returns exit code 0

**Alternative approaches considered:**

1. `let SIGNED_COUNT++` - Same issue, returns expr value
2. `SIGNED_COUNT=$((SIGNED_COUNT + 1))` - ✅ Chosen (always succeeds)
3. `((SIGNED_COUNT++)) || true` - Works but obscures intent
4. Remove `set -e` - Bad practice, loses error checking

**Files changed:**
- `.github/workflows/release.yml` - Line 459: Changed increment syntax

**Next steps:**
- Merge this PR to unblock releases
- Monitor next release to confirm all 9 archives are signed
- Consider adding workflow tests for bash script logic