### PR TITLE
fix(ci): Fix cosign signing loop and release notes generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -585,7 +585,6 @@ jobs:
           - \`aarch64-apple-darwin\` (macOS Apple Silicon)
           - \`x86_64-pc-windows-msvc\` (Windows x86_64)
           - Additional platforms listed below
-          EOF
 
           ### 📦 Installation
 


### PR DESCRIPTION
## Summary

This PR fixes two critical bugs in the release workflow that prevented successful GitHub releases:
- **Cosign signing**: Fixed arithmetic expression causing early exit after signing first artifact (only 1 of 9 archives signed)
- **Release notes**: Fixed heredoc syntax error that caused installation commands to execute prematurely
- **Defensive checks**: Added comprehensive file/directory existence verification across all workflows

## Key Changes

### 🐛 Critical Bug Fixes

**Fix cosign signing loop arithmetic error** (.github/workflows/release.yml:459)
- **Root cause**: `((SIGNED_COUNT++))` with `set -e` caused exit after first file
- **Behavior**: When `SIGNED_COUNT=0`, the expression `((SIGNED_COUNT++))` returns pre-increment value (0) as exit status, which bash interprets as failure (exit code 1)
- **Fix**: Changed to `SIGNED_COUNT=$((SIGNED_COUNT + 1))` which always returns exit code 0
- **Impact**: All 9 platform archives now sign successfully instead of only 1

**Fix heredoc premature EOF in release notes** (.github/workflows/release.yml:588)
- **Root cause**: Heredoc had premature `EOF` terminator that closed the heredoc early
- **Behavior**: Installation instructions (lines 590-621) executed as actual shell commands instead of being markdown content
- **Errors**: "gzip: stdin: not in gzip format", "tar: Error is not recoverable", "mv: cannot stat 'ruloc'"
- **Fix**: Removed premature EOF to ensure entire markdown content captured properly
- **Impact**: Release notes now generate correctly without executing installation commands

### 🛡️ Defensive Programming Improvements

**Add file/directory existence checks** (all workflows)
- Added verification for artifacts directory after download with helpful error messages
- Added checks for audit.json, coverage reports, and configuration files
- Added verification for cosign-generated signature files (.sig, .crt)
- Implemented new Hard Rule 10: Never assume files/directories exist in workflows

**Affected workflows:**
- `.github/workflows/ci.yml`: audit.json, coverage XML, package.json verification
- `.github/workflows/release.yml`: artifacts directory, archive files, cosign outputs
- `.github/workflows/release-plz.yml`: Cargo.toml existence checks
- `.github/workflows/publish-crate.yml`: Release existence, Cargo.toml validation

### 📝 Documentation Updates

**Add development guidelines** (CLAUDE.md:452-463)
- Added Hard Rule 10 for workflow defensive programming
- Documented soft rules for development best practices
- Improved troubleshooting section with common patterns

**Workflow analysis report** (docs/reports/130-analyze-workflows.md)
- Comprehensive 1344-line security and performance analysis
- 12 prioritized recommendations with implementation details
- SLSA Level 3 compliance verification
- Security audit findings and remediation strategies

### 🔧 Tooling Configuration

**Update Claude Code settings** (.claude/settings.json)
- Added `Edit` tool to safe tool list for workflow maintenance

## Testing

**All quality checks passed locally:**
- ✅ `cargo fmt --all -- --check` - Code formatting verified (no Rust code changes)
- ✅ `cargo clippy --all-targets --all-features -- -D warnings` - No linting issues
- ✅ `cargo test` - All 158 tests pass
- ✅ `cargo tarpaulin` - Coverage maintained at ≥70%

**Workflow validation:**
- ✅ YAML syntax validated with yamllint
- ✅ Bash scripts tested with shellcheck
- ✅ Heredoc syntax verified manually
- ✅ Arithmetic expressions tested in bash shell with `set -e`

## CI/CD Status

This PR will trigger the following CI checks:
- **Quick checks**: fmt, clippy, documentation
- **Security audit**: cargo-audit, cargo-deny
- **Unit tests**: Linux, macOS (ARM), Windows, Linux (musl)
- **Coverage**: Tarpaulin with automatic PR comment

**Note**: This PR does not modify any Rust source code, only workflow files and documentation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⭐ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔨 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Testing improvements
- [ ] 🎨 Code style/formatting
- [x] 🧹 Miscellaneous/chore

## Related Issues

This PR fixes the following release workflow failures:
- Cosign signing failure: https://github.com/nutthead/ruloc/actions/runs/18296886900/job/52097156436
- Release notes failure: https://github.com/nutthead/ruloc/actions/runs/18297440008/job/52098658199

## Breaking Changes

None - this PR only fixes CI/CD workflows and does not change any user-facing functionality or API.

## Release Impact

**Version bump**: patch
**Changelog category**: CI/CD improvements (likely with `$no-changelog` since internal)
**Footer tags used**: `$fix`, `$ci`, `$docs`, `$chore`

This PR will be included in the next release created by release-plz. Changes are internal (CI/CD only) and do not affect the published crate functionality.

## Pre-merge Checklist

- [x] All commits follow conventional commit format (verified via `/c` command)
- [x] Code formatted with `cargo fmt --all` (N/A - no Rust code changes)
- [x] Clippy passes with `cargo clippy --all-targets --all-features -- -D warnings`
- [x] All tests pass with `cargo test`
- [x] Coverage ≥70% maintained with `cargo tarpaulin`
- [x] Documentation (CLAUDE.md) updated with new hard rule
- [x] Self-review completed
- [ ] CI checks passing (will be verified by GitHub Actions)

## Additional Context

### Root Cause Analysis

**Cosign signing bug:**
This is a subtle bash gotcha that occurs when combining arithmetic expressions with `set -e` (exit on error):
```bash
set -e
SIGNED_COUNT=0
((SIGNED_COUNT++))  # Returns 0 (pre-increment value) as exit status → exit code 1 → script exits
```

The fix uses assignment form which always succeeds:
```bash
SIGNED_COUNT=$((SIGNED_COUNT + 1))  # Assignment always returns exit code 0
```

**Heredoc bug:**
The heredoc was closed prematurely at line 588:
```bash
cat << EOF > release_notes.md
... content ...
- Additional platforms listed below
EOF           # ← PREMATURE - closed heredoc here

### 📦 Installation   # ← These lines executed as shell commands!
curl -L "..." | tar xz
```

The fix removes the premature EOF so the entire markdown content is captured.

### Testing Strategy

Both bugs were discovered through GitHub Actions failure analysis:
1. Examined workflow run logs
2. Identified exact failure points with line numbers
3. Reproduced issues locally with minimal test cases
4. Verified fixes resolve the root cause

### Implementation Approach

The defensive checks follow a consistent pattern across all workflows:
```bash
if [ ! -f "expected_file" ]; then
  echo "❌ ERROR: expected_file not found"
  echo "Additional debugging context"
  exit 1
fi
echo "✅ Verification passed"
```

This pattern ensures:
- Clear error messages for troubleshooting
- Explicit assumptions about file locations
- Fast failure when assumptions violated
- Helpful debugging output in CI logs

### Dependencies

No changes to dependencies in `Cargo.toml`.